### PR TITLE
install DejaVuSans inside Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM python:3-slim
 
-RUN apt-get update && apt-get -y install gcc
+RUN apt-get update && \
+    apt-get install -y \
+    gcc \
+    fonts-dejavu-core \
+    && rm -rf /var/lib/apt/lists/*
 COPY src/ /app/src
 COPY requirements.txt /app/
 RUN pip install -r /app/requirements.txt


### PR DESCRIPTION
should solve:
```
Traceback (most recent call last):
  File "/app/src/main.py", line 24, in <module>
    bot.add_cog(Game(bot, gameHelper))
  File "/app/src/bot/game.py", line 19, in __init__
    self.image_generator = ImageGenerator()
  File "/app/src/game/image_generator.py", line 16, in __init__
    self.font = ImageFont.truetype("DejaVuSans.ttf", 25)
  File "/usr/local/lib/python3.9/site-packages/PIL/ImageFont.py", line 852, in truetype
    return freetype(font)
  File "/usr/local/lib/python3.9/site-packages/PIL/ImageFont.py", line 849, in freetype
    return FreeTypeFont(font, size, index, encoding, layout_engine)
  File "/usr/local/lib/python3.9/site-packages/PIL/ImageFont.py", line 209, in __init__
    self.font = core.getfont(
OSError: cannot open resource
```
inside the docker container